### PR TITLE
Remove extra `self = [super init]`.

### DIFF
--- a/src/MDFRobotoFontLoader.m
+++ b/src/MDFRobotoFontLoader.m
@@ -83,7 +83,6 @@ NSString *const MDFRobotoBundle = @"MaterialRobotoFontLoader.bundle";
 - (instancetype)initInternal {
   self = [super init];
   if (self) {
-    self = [super init];
     _baseBundle = [MDFRobotoFontLoader baseBundle];
     _bundleFileName = MDFRobotoBundle;
   }


### PR DESCRIPTION
Not sure if this is done on purpose, but in case it isn't, this PR removes it.